### PR TITLE
Support MSVC with current Boost.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Emacs backup files
 *~
+
+# Qt Creator user's project settings
+CMakeLists.txt.user

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 # Qt Creator user's project settings
 CMakeLists.txt.user
+
+# Build folder from the README
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,10 @@ endforeach()
 
 if (${Boost_FOUND})
     # Asio as the execution queue *and* co_await
+    find_package( Threads REQUIRED )
     add_executable( ac asio_coro.cpp )
     target_compile_options( ac PUBLIC -fcoroutines-ts -stdlib=libc++ -D_LIBCPP_DEBUG_=1 )
-    target_link_libraries( ac PUBLIC -stdlib=libc++ PRIVATE Boost::boost pthread Boost::system )
+    target_link_libraries( ac PUBLIC -stdlib=libc++ PRIVATE Boost::boost Threads::Threads Boost::system )
 else()
     message( WARNING "Boost not found; Asio example will not be built" )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package( Boost 1.67 COMPONENTS system )
 find_package( Qt5Widgets REQUIRED )
 
 add_compile_options( -Wall -Wextra -Werror )
-set( CMAKE_CXX_FLAGS_DEBUG "-g -O0 -fno-omit-frame-pointer -D_LIBCPP_DEBUG=1" )
+set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_LIBCPP_DEBUG=1" )
 
 # a simple generator
 add_executable( mg manual_generator.cpp )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_compile_options( /W4 /WX )
     set( WITH_COROUTINES /await )
+    if ( MSVC_VERSION LESS 1920 )
+        add_compile_definitions( INTERNAL_VOID_SPECIALIZATION )
+    endif()
 endif()
 
 # a simple generator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set( CMAKE_CXX_STANDARD 17 )
 # dependencies
 if ( MSVC )
     # default prebuilt boost installation directory
-    set( BOOST_ROOT "c:/local/boost_1_70_0" )
+    set( BOOST_ROOT "c:/local/boost_1_70_0" CACHE PATH "Path to the boost install directory.")
 endif()
 find_package( Boost 1.70 COMPONENTS system )
 find_package( Qt5Widgets REQUIRED )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required( VERSION 3.5.0 )
+if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.15.0 )
+    # Do not insert "/W3" by default into MSVC compile options.
+    # This quietens warning level override warnings
+    cmake_policy( SET CMP0092 NEW )
+endif()
 
 # create compile_commands.json for tools
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
@@ -9,8 +14,16 @@ set( CMAKE_CXX_STANDARD 17 )
 find_package( Boost 1.67 COMPONENTS system )
 find_package( Qt5Widgets REQUIRED )
 
-add_compile_options( -Wall -Wextra -Werror )
-set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_LIBCPP_DEBUG=1" )
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_compile_options( -Wall -Wextra -Werror )
+    add_compile_options( -stdlib=libc++ )
+    add_link_options( -stdlib=libc++ )
+    set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_LIBCPP_DEBUG=1" )
+    set( WITH_COROUTINES -fcoroutines-ts )
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    add_compile_options( /W4 /WX )
+    set( WITH_COROUTINES /await )
+endif()
 
 # a simple generator
 add_executable( mg manual_generator.cpp )
@@ -24,25 +37,22 @@ add_executable( cac cb_as_coro.cpp )
 # Qt basic example, no coroutines
 QT5_WRAP_CPP( CR_MOC_SRC colorrect.h )
 add_executable( qb qt_basic.cpp ${CR_MOC_SRC} colorrect.cpp )
-target_compile_options( qb PUBLIC -stdlib=libc++ )
-target_link_libraries( qb Qt5::Widgets -stdlib=libc++ )
+target_link_libraries( qb Qt5::Widgets )
 
 # Qt with coroutines
 add_executable( qc qt_coro.cpp ${CR_MOC_SRC} colorrect.cpp )
-target_compile_options( qc PUBLIC -fcoroutines-ts -stdlib=libc++ )
-target_link_libraries( qc Qt5::Widgets -stdlib=libc++ )
+target_link_libraries( qc Qt5::Widgets )
 
-foreach( ex mg ba cb cac )
-    target_compile_options( ${ex} PUBLIC -fcoroutines-ts -stdlib=libc++ -D_LIBCPP_DEBUG_=1 )
-    target_link_libraries( ${ex} PUBLIC -stdlib=libc++ )
+foreach( target mg ba cb cac qc )
+    target_compile_options( ${target} PUBLIC ${WITH_COROUTINES} )
 endforeach()
 
 if (${Boost_FOUND})
     # Asio as the execution queue *and* co_await
     find_package( Threads REQUIRED )
     add_executable( ac asio_coro.cpp )
-    target_compile_options( ac PUBLIC -fcoroutines-ts -stdlib=libc++ -D_LIBCPP_DEBUG_=1 )
-    target_link_libraries( ac PUBLIC -stdlib=libc++ PRIVATE Boost::boost Threads::Threads Boost::system )
+    target_compile_options( ac PUBLIC ${WITH_COROUTINES} )
+    target_link_libraries( ac PRIVATE Boost::boost Threads::Threads Boost::system )
 else()
     message( WARNING "Boost not found; Asio example will not be built" )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 set( CMAKE_CXX_STANDARD 17 )
 
 # dependencies
-find_package( Boost 1.67 COMPONENTS system )
+find_package( Boost 1.70 COMPONENTS system )
 find_package( Qt5Widgets REQUIRED )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 set( CMAKE_CXX_STANDARD 17 )
 
 # dependencies
+if ( MSVC )
+    # default prebuilt boost installation directory
+    set( BOOST_ROOT "c:/local/boost_1_70_0" )
+endif()
 find_package( Boost 1.70 COMPONENTS system )
 find_package( Qt5Widgets REQUIRED )
 
@@ -56,6 +60,12 @@ if (${Boost_FOUND})
     add_executable( ac asio_coro.cpp )
     target_compile_options( ac PUBLIC ${WITH_COROUTINES} )
     target_link_libraries( ac PRIVATE Boost::boost Threads::Threads Boost::system )
+    if ( MSVC )
+        # work around packaging glitches in official prebuilt boost packages
+        target_link_directories( ac PRIVATE $<IF:$<CONFIG:Debug>,${Boost_LIBRARY_DIR_DEBUG},${Boost_LIBRARY_DIR_RELEASE}> )
+        # silence deprecated allocator warnings originating in Boost headers
+        target_compile_definitions( ac PRIVATE _SILENCE_CXX17_ALLOCATOR_VOID_DEPRECATION_WARNING )
+    endif()
 else()
     message( WARNING "Boost not found; Asio example will not be built" )
 endif()

--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ Common options to cmake:
 
 - Path to the compiler, usually needed for clang: `-DCMAKE_CXX_COMPILER=/path/to/clang++`
 
+- Path to Boost - needed when Boost is in a less-than-usual location: `-DBOOST_ROOT=/path/to/boost_install`. This variable is cached and needs to be given only once per build location.
+
 - Building a release build with debug information: `-DCMAKE_BUILD_TYPE=relwithdebinfo`
 
-It is not necessary to pass the path to the MSVC compiler usually, but the build has to start
-from the Visual Studio Command Line.
+### Platform Notes
 
-gcc does not support coroutines at this time.
+- It is not necessary to pass the path to the MSVC compiler, but the build has to start from the Visual Studio Command Line.
+
+- No additional cmake options are needed on macOS. Once macPorts updates their boost to 1.77.0, it will be detected by the build and used.
+
+- gcc does not support coroutines at this time.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@ The Qt examples are a bit more complex and involve coroutines that use 0, 1, and
 
 ## To Build
 
-It's the usual CMake flow, but your compiler needs to be a recent Clang:
+It's the usual CMake flow, but your compiler needs to be a recent Clang or MSVC 2017+:
 
-`mkdir build;cd build;cmake -DCMAKE_CXX_COMPILER=/path/to/clang++ ..`
+    mkdir build; cd build; cmake ..
 
-It should be possible to port this to MSVC with only a few changes, if anyone wants to try it.
+Common options to cmake:
+
+- Path to the compiler, usually needed for clang: `-DCMAKE_CXX_COMPILER=/path/to/clang++`
+
+- Building a release build with debug information: `-DCMAKE_BUILD_TYPE=relwithdebinfo`
+
+It is not necessary to pass the path to the MSVC compiler usually, but the build has to start
+from the Visual Studio Command Line.
+
 gcc does not support coroutines at this time.

--- a/asio_coro.cpp
+++ b/asio_coro.cpp
@@ -30,24 +30,22 @@ SOFTWARE.
 #include <iostream>
 
 #include <experimental/coroutine>
-#include <boost/asio/experimental/co_spawn.hpp>
+#include <boost/asio/co_spawn.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <boost/asio/use_awaitable.hpp>
 
-using boost::asio::experimental::co_spawn;
-namespace this_coro = boost::asio::experimental::this_coro;
+using boost::asio::awaitable;
+using boost::asio::co_spawn;
 using boost::asio::io_context;
-
-template <typename T>
-  using awaitable = boost::asio::experimental::awaitable<
-    T, boost::asio::io_context::executor_type>;
+namespace this_coro = boost::asio::this_coro;
 
 awaitable<int> multiply(int x, int y) {
     // arbitrary async operation so we suspend and resume from the run queue
-    auto token = co_await this_coro::token();
-    boost::asio::steady_timer t(token.get_executor().context(),
+    auto token = co_await this_coro::executor_t::executor_t();
+    boost::asio::steady_timer t(token,
                                 boost::asio::chrono::milliseconds(50));
-    co_await t.async_wait(token);  // suspend and run something else
+    co_await t.async_wait(boost::asio::use_awaitable);  // suspend and run something else
     co_return x * y;
 }
 

--- a/co_awaiter.hpp
+++ b/co_awaiter.hpp
@@ -54,6 +54,12 @@ struct await_return_object {
     };
 
     // void specialization to replace with return_void() is below at namespace scope
+#ifdef INTERNAL_VOID_SPECIALIZATION
+    template<>
+    struct promise_base<void> {
+        void return_void() const noexcept {}
+    };
+#endif // INTERNAL_VOID_SPECIALIZATION
 
     struct promise_type : promise_base<T> {
         // coroutine promise requirements:
@@ -82,11 +88,13 @@ private:
 
 };
 
+#ifndef INTERNAL_VOID_SPECIALIZATION
 template<>
 template<>
 struct await_return_object<void>::promise_base<void> {
     void return_void() const noexcept {
     }
 };
+#endif // INTERNAL_VOID_SPECIALIZATION
 
 #endif // CO_AWAITER_HPP

--- a/my_awaitable.hpp
+++ b/my_awaitable.hpp
@@ -28,7 +28,7 @@ SOFTWARE.
 #include <type_traits>
 
 template<typename F,
-         typename ReturnType = typename std::remove_cv_t<std::result_of_t<F()>>>
+         typename ReturnType = typename std::remove_cv_t<std::invoke_result_t<F>>>
 struct my_awaitable {
     // construct with a nullary function that does something and returns a value
     my_awaitable(F work_fn) : work_(work_fn) {}

--- a/qtcoro.hpp
+++ b/qtcoro.hpp
@@ -66,6 +66,12 @@ struct return_object {
         }
     };
     // void specialization to replace with return_void() is below at namespace scope
+#ifdef INTERNAL_VOID_SPECIALIZATION
+    template<>
+    struct promise_base<void> {
+        void return_void() const noexcept {}
+    };
+#endif // INTERNAL_VOID_SPECIALIZATION
 
     struct promise_type : promise_base<T> {
         // coroutine promise requirements:
@@ -95,12 +101,14 @@ private:
 };
 
 // that specialization for void values
+#ifndef INTERNAL_VOID_SPECIALIZATION
 template<>
 template<>
 struct return_object<void>::promise_base<void> {
     void return_void() const noexcept {
     }
 };
+#endif // INTERNAL_VOID_SPECIALIZATION
 
 //
 // Slot "factory"


### PR DESCRIPTION
Add MSVC support to the build system. Work around gotchas in MSVC 2017's C++17 implementation. Update Boost to the current version 1.70, and update the code to work with it: coroutine support in asio is not experimental anymore.